### PR TITLE
Fix Error on Admin Pages After Initial Setup

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -38,8 +38,8 @@
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>3.1</version>
                 <configuration>
-                    <source>6</source>
-                    <target>6</target>
+                    <source>7</source>
+                    <target>7</target>
                 </configuration>
             </plugin>
             <plugin>

--- a/core/src/main/java/com/nateyolles/sling/publick/services/impl/SystemSettingsServiceImpl.java
+++ b/core/src/main/java/com/nateyolles/sling/publick/services/impl/SystemSettingsServiceImpl.java
@@ -91,7 +91,7 @@ public class SystemSettingsServiceImpl implements SystemSettingsService {
     public String getBlogName() {
         try {
             return JcrUtils.getStringProperty(systemConfigNode, "blogName", null);
-        } catch (RepositoryException e) {
+        } catch (RepositoryException | NullPointerException e) {
             return null;
         }
     }


### PR DESCRIPTION
It was throwing a null pointer exception on a number of admin pages as the site name was not set.
